### PR TITLE
feat(ui/js): estados visibles del botón, modo 'Nuevo sorteo' y limpieza de lista/resultado

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
             <ul id="resultado" class="result-list" aria-live="polite"></ul>
 
             <div class="button-container">
-                <button class="button-draw" onclick="sortearAmigo()" aria-label="Sortear amigo secreto">
+                <button class="button-draw" onclick="sortearAmigo()" aria-label="Sortear amigo secreto" disabled aria-disabled="true">
                     <img src="assets/play_circle_outline.png" alt="Ícono para sortear">
                     Sortear amigo
                 </button>

--- a/style.css
+++ b/style.css
@@ -92,7 +92,7 @@ body {
     justify-content: center;
 }
 
-/* Estilos de entrada de texto */
+/* Estilos de entrada de texto (no usada directamente, pero mantenida por si acaso) */
 .input-title {
     flex: 1;
     padding: 10px 15px;
@@ -104,7 +104,7 @@ body {
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 }
 
-/* Estilos de botón */
+/* Estilos base para todos los botones */
 button {
     padding: 15px 30px;
     font-family: "Inter", sans-serif;
@@ -115,14 +115,14 @@ button {
     cursor: pointer;
 }
 
+/* Botón Añadir: activo en naranja */
 .button-add {
-    background-color: var(--color-tertiary);
-    color: var(--color-text);
+    background-color: var(--color-button);
+    color: var(--color-white);
     border-radius: 0 25px 25px 0;
 }
-
 .button-add:hover {
-    background-color: #a1a1a1;
+    background-color: var(--color-button-hover);
 }
 
 /* Listas */
@@ -142,7 +142,7 @@ ul {
     text-align: center;
 }
 
-/* Botón de sortear título */
+/* Botón sortear: naranja cuando está habilitado, gris cuando está deshabilitado */
 .button-draw {
     display: flex;
     align-items: center;
@@ -152,11 +152,18 @@ ul {
     background-color: var(--color-button);
     font-size: 16px;
 }
-
 .button-draw img {
     margin-right: 40px;
 }
-
 .button-draw:hover {
     background-color: var(--color-button-hover);
+}
+
+/* Estado deshabilitado (visual y accesible) */
+.button-draw[disabled],
+.button-draw[aria-disabled="true"] {
+    background-color: #bdbdbd !important;
+    border-color: #999;
+    cursor: not-allowed;
+    box-shadow: none;
 }


### PR DESCRIPTION
### Qué cambia
- Botón **Añadir** ahora en color naranja (activo).
- Botón **Sortear amigo**:
  - Gris cuando está deshabilitado (menos de 2 participantes) + `cursor: not-allowed`.
  - Naranja cuando está habilitado.
  - Tras el sorteo cambia a **“Nuevo sorteo”**; al presionarlo limpia la lista y el resultado, regresando a “Sortear amigo”.
- Accesibilidad: se usa `aria-disabled` y `title` con mensajes contextuales.

### Razón
- Hacer explícito el estado interactivo del botón para mejorar UX.
- Flujo claro: sorteo → ver resultados → iniciar nuevo sorteo con un solo clic.

### Notas
- Si se agrega un nuevo participante estando en modo “Nuevo sorteo”, el sistema vuelve a modo “Sortear amigo”.
